### PR TITLE
Fix base64 query param parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             const results = regex.exec(url);
             if (!results) return null;
             if (!results[2]) return '';
-            return decodeURIComponent(results[2].replace(/\+/g, ' '));
+            return decodeURIComponent(results[2]);
         }
 
         // 当页面加载时


### PR DESCRIPTION
## Summary
- don't replace `+` when decoding query params so base64 works

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f8bc1b3388321a7298010a5b1a51d